### PR TITLE
More intrinsic functions/subroutines. Better rule consistency. Fixes #10 #11 #12.

### DIFF
--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -11,318 +11,85 @@
 ]
 'firstLineMatch': '(?i)-[*]- mode: f90 -[*]-'
 'name': 'Fortran - Modern'
+'injections':
+  'source.fortran - ( string | comment )':
+    'patterns':[
+      {'include': '#comments'}
+      {'include': '#derived-type-definition'}
+      {'include': '#interface-blocks'}
+      {'include': '#intrinsic-functions'}
+      {'include': '#intrinsic-subroutines'}
+      {
+        'comment': 'Non-intrinsic subroutines.'
+        'begin': '(?<=call|%)\\s+([a-z]\\w*)\\s*\\('
+        'end': '\\)'
+        'patterns':[
+          {'include': '#procedure-call-dummy-variable'}
+          {'include': '$self'}
+        ]
+      }
+      {'include': '#data-statements'}
+      {'include': '#IO-statements'}
+      {
+        'comment': 'logical operators in symbolic format'
+        'match': '(\\=\\=|\\/\\=|\\>\\=|\\>|\\<|\\<\\=)'
+        'name': 'keyword.operator.logical.fortran.modern'
+      }
+      {
+        'comment': 'operators'
+        'match': '(\\%|\\=\\>)'
+        'name': 'keyword.operator.fortran.modern'
+      }
+      {
+        'comment': 'Line of type specification'
+        'name': 'meta.specification.fortran'
+        'begin': '\\b(class|type)\\b(?=\\s*\\()'
+        'beginCaptures':
+          '1': 'name': 'storage.type.fortran.modern'
+        'end': '(?=[;!\\n])'
+        'patterns': [
+          {'include': '$self'}
+        ]
+      }
+      {
+        'comment': 'statements controling the flow of the program'
+        'match': '(?i)\\b(select\\s+case|case(\\s+default)?|end\\s+select|use|(end\\s+)?forall)\\b'
+        'name': 'keyword.control.fortran.modern'
+      }
+    ]
+  'meta.specification.fortran':
+    'patterns':[
+      {
+        'match': '(?i)\\b(allocatable|optional|pointer|target)\\b'
+        'name': 'storage.modifier.fortran.modern'
+      }
+    ]
+  'meta.module.fortran.modern meta.specification.fortran - meta.function.fortran':
+    'patterns':[
+      {'include': '#access-attributes'}
+    ]
+  'source.fortran - meta':
+    'patterns':[
+      {'include': '#module-definition'}
+    ]
 'patterns': [
   {
     'include': 'source.fortran'
   }
-  {'include': '#interface-blocks'}
-  {'include': '#intrinsic-functions'}
-  {'include': '#intrinsic-subroutines'}
-  {
-    'comment': 'Non-intrinsic subroutines.'
-    'begin': '(?<=call|%)\\s+([a-z]\\w*)\\s*\\('
-    'end': '\\)'
-    'patterns':[
-      {'include': '#procedure-call-dummy-variable'}
-      {'include': '$self'}
-    ]
-  }
-  {'include': '#data-statements'}
-  {'include': '#IO-statements'}
-  {
-    'name': 'meta.derived-type.definition.fortran2008'
-    'begin': '(?i)^\\s*(type)\\b(?![\\t ]*\\()'
-    'beginCaptures':
-      '1': 'name': 'support.type.derived-type.fortran2008'
-    'end': '(?=[;!\\n])'
-    'patterns': [
-      {# attribute list
-        'comment': 'derived-type attribute list'
-        'begin': '(?i)(?<=type)\\b(?![\\t ]*\\()'
-        'end': '(?i)(::)|(?=[a-z]|[;!\\n])'
-        'endCaptures':
-          '1': 'name': 'keyword.operator.double-colon.fortran'
-        'patterns': [
-          {
-            'begin': '(?i)(,)'
-            'beginCaptures':
-              '1': 'name': 'punctuation.comma.fortran'
-            'end': '(?=::|[,;!\\n])'
-            'patterns':[
-              {'include': '#access-attributes'}
-              {
-                'begin': '(?i)\\b(extends)\\s*\\((?!([^;!\n](?!::))*(sequence))'
-                'beginCaptures':
-                  '1': 'name': 'keyword.other.attribute.derived-type.fortran.2008'
-                'end': '\\)'
-                'patterns':[
-                  {
-                    'name': 'entity.name.derived-type.fortran.2008'
-                    'match': '(?i)\\b([a-z]\\w*)\\b'
-                  }
-                ]
-              }
-              {
-                'begin': '\\b(bind)\\s*\\('
-                'beginCaptures':
-                  '1': 'name': 'keyword.other.attribute.derived-type.fortran.2008'
-                'end': '\\)'
-                'patterns':[
-                  {
-                    'name': 'entity.name.bound-type.fortran.2008'
-                    'match': '(?i)\\b(c)\\b'
-                  }
-                ]
-              }
-              {
-                'name': 'keyword.other.attribute.derived-type.fortran.2008'
-                'match': '(?i)\\b(sequence)\\b(?!([^;!\n](?!::))*(extends))'
-              }
-              {
-                'name': 'invalid.error.fortran'
-                'match': '(?i)\\b\\w+\\b'
-              }
-            ]
-          }
-        ]
-      }
-      {# body
-        'begin': '(?i)\\b([a-z]\\w*)\\b'
-        'beginCaptures':
-          '1': 'name': 'entity.name.derived-type.fortran.2008'
-        'end': '(?i)^\\s*(end)[\\t ]*(type)(?:\\s+(?:(\\1)|(\\w+)))?\\b'
-        'endCaptures':
-          '1': 'name': 'keyword.control.end.derived-type.fortran.2008'
-          '2': 'name': 'support.type.derived-type.fortran.2008'
-          '3': 'name': 'entity.name.derived-type.fortran.2008'
-          '4': 'name': 'invalid.error.fortran.2008'
-        'patterns':[
-          {'include': '$base'}
-          {# parameter definition statements
-            'match': '(?i)^\\s*(integer)[\\t ]*(,)\\s*(kind|len)\\s*(?:(::)\\s*([a-z]\\w*)?)?\\s*(?=[;!\\n])'
-            'captures':
-              '1': 'name': 'storage.type.integer.fortran'
-              '2': 'name': 'punctuation.comma.fortran'
-              '3': 'name': 'keyword.other.attribute.derived-type.parameter.fortran.2008'
-              '4': 'name': 'keyword.operator.double-colon.fortran'
-              '5': 'name': 'entity.name.derived-type.parameter.fortran.2008'
-          }
-          {# attribute statements
-            'name': 'keyword.other.attribute.derived-type.fortran.2008'
-            'match': '(?i)^\\s*(private|public|sequence)\\b\\s*\\n'
-          }
-          {# contains section
-            'comment': 'derived-type contains construct'
-            'begin': '(?i)^\\s*(contains)(?=\\s*[!$\\n])'
-            'beginCaptures':
-              '1': 'name': 'keyword.type-contains.fortran2008'
-            'end': '(?i)(?=\\s+end\\b)'
-            'patterns': [
-              {'include': '$base'}
-              {
-                'name': 'keyword.other.attribute.statement.fortran.2008'
-                'match': '(?i)^\\s*private\\b'
-              }
-              {# generic procedure statement
-                'begin': '(?i)^\\s*(generic)\\b'
-                'beginCaptures':
-                  '1': 'name': 'support.function.generic.type-bound.fortran.2008'
-                'end': '(?=[;!\\n])'
-                'patterns':[
-                  {# attribute list
-                    'comment': 'derived-type attribute list'
-                    'begin': '(?i)(?<=generic)'
-                    'end': '(?i)(::)|(?=[a-z]|[;!\\n])'
-                    'endCaptures':
-                      '1': 'name': 'keyword.operator.double-colon.fortran'
-                    'patterns': [
-                      {
-                        'begin': '(?i)(,)'
-                        'beginCaptures':
-                          '1': 'name': 'punctuation.comma.fortran'
-                        'end': '(?=::|[,;!\\n])'
-                        'patterns':[
-                          {'include': '#access-attributes'}
-                        ]
-                      }
-                    ]
-                  }
-                  {# assignment
-                    'comment': 'type bound procedure binding name'
-                    'match': '(?i)(?<=generic|::)[\\t ]*\\b(assignment)[\\t ]*\\([\\t ]*(\\=)[\\t ]*\\)'
-                    'captures':
-                      '1': 'name': 'keyword.other.assignment.fortran.2008'
-                      '2': 'name': 'keyword.operator.fortran.2008'
-                  }
-                  {# operator
-                    'comment': 'type bound procedure binding name'
-                    'match': '(?i)(?<=generic|::)[\\t ]*\\b(operator)[\\t ]*\\([\\t ]*(\\.[a-z]*\\.|\\=\\=|\\>\\=|\\<\\=|\\/\\=|\\>|\\<)[\\t ]*\\)'
-                    'captures':
-                      '1': 'name': 'keyword.other.assignment.fortran.2008'
-                      '2': 'name': 'keyword.operator.fortran.2008'
-                  }
-                  {# binding list
-                    'begin': '\\=\\>'
-                    'beginCaptures':
-                      '0': 'name': 'keyword.operator.pointer.fortran.2008'
-                    'end': '(?=[;!\\n])'
-                    'patterns':[
-                      {
-                        'name': 'entity.name.function.procedure.fortran.2008'
-                        'match': '(?i)\\b[a-z]\\w*\\b'
-                      }
-                    ]
-                  }
-                ]
-              }
-              {# procedure statement
-                'comment': 'type bound procedure statement'
-                'begin': '(?i)^\\s*(procedure)\\b(?:[\\t ]*\\(([a-z]\\w*)\\))?'
-                'beginCaptures':
-                  '1': 'name': 'support.function.procedure.type-bound.fortran.2008'
-                  '2': 'name': 'entity.name.function.procedure.fortran.2008'
-                'end': '(?i)(?=[;!$\\n])'
-                'patterns':[
-                  {# attribute list
-                    'comment': 'derived-type attribute list'
-                    'begin': '(?i)(?<=procedure|\\))\\b(?![\\t ]*\\()'
-                    'end': '(?i)(::)|(?=[a-z]|[;!\\n])'
-                    'endCaptures':
-                      '1': 'name': 'keyword.operator.double-colon.fortran'
-                    'patterns': [
-                      {
-                        'begin': '(?i)(,)'
-                        'beginCaptures':
-                          '1': 'name': 'punctuation.comma.fortran'
-                        'end': '(?=::|[,;!\\n])'
-                        'patterns':[
-                          {'include': '#access-attributes'}
-                          {
-                            'match': '(?i)\\b(pass)\\b[\\t ]*(?:\\([\\t ]*([a-z]\\w*)[\\t ]*\\))?(?!([^;!\n](?!::))*(nopass|pass))'
-                            'captures':
-                              '1': 'name': 'keyword.other.attribute.procedure.fortran.2008'
-                              '2': 'name': 'keyword.other.attribute.procedure.fortran.2008'
-                            'end': '(?=[,:;!\\n])'
-                          }
-                          {
-                            'name': 'keyword.other.attribute.procedure.fortran.2008'
-                            'match': '(?i)\\b(nopass)\\b(?!([^;!\n](?!::))*(nopass|pass))'
-                          }
-                          {
-                            'name': 'keyword.other.attribute.procedure.fortran.2008'
-                            'match': '(?i)\\b(deferred|non_overridable)\\b(?!([^;!\n](?!::))*(deferred|non_overridable))'
-                          }
-                          {
-                            'name': 'invalid.error.fortran'
-                            'match': '(?i)\\b\\w+\\b'
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                  {# binding name
-                    'comment': 'type bound procedure binding name'
-                    'match': '(?i)(?<=procedure|::)[\\t ]*\\b([a-z]\\w*\\b)(?:[\\t ]*(\\=\\>)(?:[\\t ]*([a-z]\\w*\\b))?)?'
-                    'captures':
-                      '1': 'name': 'entity.name.function.procedure.fortran.2008'
-                      '2': 'name': 'keyword.other.operator.fortran.2008'
-                      '3': 'name': 'entity.name.function.procedure.fortran.2008'
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  {
-    'begin': '(^[ \\t]+)?(?=!-)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.whitespace.comment.leading.ruby'
-    'end': '(?!\\G)'
-    'patterns': [
-      {
-        'begin': '!-'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.fortran'
-        'end': '\\n'
-        'name': 'comment.line.exclamation.mark.fortran.modern'
-        'patterns': [
-          {
-            'match': '\\\\\\s*\\n'
-          }
-        ]
-      }
-    ]
-  }
-  {
-    'begin': '(^[ \\t]+)?(?=!)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.whitespace.comment.leading.ruby'
-    'end': '(?!\\G)'
-    'patterns': [
-      {
-        'begin': '!'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.fortran'
-        'end': '\\n'
-        'name': 'comment.line.exclamation.fortran.modern'
-        'patterns': [
-          {
-            'match': '\\\\\\s*\\n'
-          }
-        ]
-      }
-    ]
-  }
-  {
-    'comment': 'statements controling the flow of the program'
-    'match': '(?i)\\b(select\\s+case|case(\\s+default)?|end\\s+select|use|(end\\s+)?forall)\\b'
-    'name': 'keyword.control.fortran.modern'
-  }
-  {
-    'comment': 'logical operators in symbolic format'
-    'match': '\\b(\\=\\=|\\/\\=|\\>\\=|\\>|\\<|\\<\\=)\\b'
-    'name': 'keyword.operator.logical.fortran.modern'
-  }
-  {
-    'comment': 'operators'
-    'match': '(\\%|\\=\\>)'
-    'name': 'keyword.operator.fortran.modern'
-  }
-  {
-    'comment': 'programming units'
-    'match': '\\b(?i:((end\\s*)?(procedure|module)))\\b'
-    'name': 'keyword.other.programming-units.fortran.modern'
-  }
-  {
-    'comment': 'Line of type specification'
-    'name': 'meta.specification.fortran.modern'
-    'begin': '\\b(class|type)\\b(?=\\s*\\()'
-    'beginCaptures':
-      '1': 'name': 'storage.type.fortran.modern'
-    'end': '(?=[;!\\n])'
-    'patterns': [
-      {'include': '$self'}
-    ]
-  }
-  {
-    'match': '\\b(?i:(optional|recursive|pointer|allocatable|target|private|public))\\b'
-    'name': 'storage.modifier.fortran.modern'
-  }
 ]
 'repository':
+  # attributes:
   'access-attributes':
     {
       'comment': 'Introduced in the Fortran 1990 standard.'
       'name': 'keyword.other.attribute.fortran.modern'
       'match': '(?i)\\b(private|public)\\b(?!([^;!\\n](?!::))*\\b(private|public)\\b)'
     }
+  # comments:
+  'comments':
+    'name': 'comment.line.fortran.modern'
+    'begin': '!'
+    'end': '(?=\\n)'
   # interfaces:
   'interface-blocks':
     'patterns':[
@@ -650,6 +417,9 @@
         ]
       }
     ]
+  'procedure-call-dummy-variable':
+    'name': 'variable.parameter.dummy-variable.fortran.modern'
+    'match': '(?i)(?<=[\\,\\(])\\s*([a-z]\\w*)(?=\\s*\\=)'
   # statements:
   'data-statements':
     'comment': 'Data statements introduced in the Fortran 1990 standard.'
@@ -679,10 +449,228 @@
         ]
       }
     ]
-
-
-  'procedure-call-dummy-variable':
-    'name': 'variable.parameter.dummy-variable.fortran.modern'
-    'match': '(?i)(?<=[\\,\\(])\\s*([a-z]\\w*)(?=\\s*\\=)'
+  # definitions:
+  'module-definition':
+    'name': 'meta.module.fortran.modern'
+    'begin': '(?ix)^\\s*(module)(\\s+[a-z]\\w*)?\\b'
+    'beginCaptures':
+      '1': 'name': 'keyword.other.module.fortran.open'
+    'end': '(?ix)^\\s*(end)\\b(?:\\s*(module)(?:\\s+(\\2)|\\s+(\\w*))?)?\\b
+      (?=\\s*[;!\\n])'
+    'endCaptures':
+      '1': 'name': 'keyword.other.end.module.fortran'
+      '2': 'name': 'keyword.other.module.fortran'
+      '3': 'name': 'entity.name.module.fortran'
+      '4': 'name': 'invalid.error.fortran'
+    'patterns': [
+      {'include': '$self'}
+      {'include': '#access-attributes'}
+    ]
+  'derived-type-definition':
+    'name': 'meta.derived-type.definition.fortran.modern'
+    'begin': '(?i)^\\s*(type)\\b(?!\\s*\\()'
+    'beginCaptures':
+      '1': 'name': 'support.type.derived-type.fortran.modern'
+    'end': '(?=[;!\\n])'
+    'patterns': [
+      {# attribute list
+        'comment': 'derived-type attribute list'
+        'begin': '(?i)(?<=type)\\b(?!\\s*\\()'
+        'end': '(?i)(::)|(?=[a-z]|[;!\\n])'
+        'endCaptures':
+          '1': 'name': 'keyword.operator.double-colon.fortran'
+        'patterns': [
+          {
+            'begin': '(?i)(,)'
+            'beginCaptures':
+              '1': 'name': 'punctuation.comma.fortran'
+            'end': '(?=::|[,;!\\n])'
+            'patterns':[
+              {'include': '#access-attributes'}
+              {
+                'begin': '(?i)\\b(extends)\\s*\\((?!([^;!\\n](?!::))*(sequence))'
+                'beginCaptures':
+                  '1': 'name': 'keyword.other.attribute.derived-type.fortran.modern'
+                'end': '\\)'
+                'patterns':[
+                  {
+                    'name': 'entity.name.derived-type.fortran.modern'
+                    'match': '(?i)\\b([a-z]\\w*)\\b'
+                  }
+                ]
+              }
+              {
+                'begin': '\\b(bind)\\s*\\('
+                'beginCaptures':
+                  '1': 'name': 'keyword.other.attribute.derived-type.fortran.modern'
+                'end': '\\)'
+                'patterns':[
+                  {
+                    'name': 'entity.name.bound-type.fortran.modern'
+                    'match': '(?i)\\b(c)\\b'
+                  }
+                ]
+              }
+              {
+                'name': 'keyword.other.attribute.derived-type.fortran.modern'
+                'match': '(?i)\\b(sequence)\\b(?!([^;!\\n](?!::))*(extends))'
+              }
+              {
+                'name': 'invalid.error.fortran'
+                'match': '(?i)\\b\\w+\\b'
+              }
+            ]
+          }
+        ]
+      }
+      {# body
+        'begin': '(?i)\\b([a-z]\\w*)\\b'
+        'beginCaptures':
+          '1': 'name': 'entity.name.derived-type.fortran.modern'
+        'end': '(?i)^\\s*(end)\\s*(type)(?:\\s+(?:(\\1)|(\\w+)))?\\b'
+        'endCaptures':
+          '1': 'name': 'keyword.control.end.derived-type.fortran.modern'
+          '2': 'name': 'support.type.derived-type.fortran.modern'
+          '3': 'name': 'entity.name.derived-type.fortran.modern'
+          '4': 'name': 'invalid.error.fortran.modern'
+        'patterns':[
+          {'include': '$self'}
+          {# parameter definition statements
+            'match': '(?i)^\\s*(integer)\\s*(,)\\s*(kind|len)\\s*(?:(::)\\s*([a-z]\\w*)?)?\\s*(?=[;!\\n])'
+            'captures':
+              '1': 'name': 'storage.type.integer.fortran'
+              '2': 'name': 'punctuation.comma.fortran'
+              '3': 'name': 'keyword.other.attribute.derived-type.parameter.fortran.modern'
+              '4': 'name': 'keyword.operator.double-colon.fortran'
+              '5': 'name': 'entity.name.derived-type.parameter.fortran.modern'
+          }
+          {# attribute statements
+            'name': 'keyword.other.attribute.derived-type.fortran.modern'
+            'match': '(?i)^\\s*(private|public|sequence)\\b\\s*\\n'
+          }
+          {# contains section
+            'comment': 'derived-type contains construct'
+            'begin': '(?i)^\\s*(contains)(?=\\s*[!$\\n])'
+            'beginCaptures':
+              '1': 'name': 'keyword.type-contains.fortran.modern'
+            'end': '(?i)(?=\\s+end\\b)'
+            'patterns': [
+              {'include': '$self'}
+              {
+                'name': 'keyword.other.attribute.statement.fortran.modern'
+                'match': '(?i)^\\s*private\\b'
+              }
+              {# generic procedure statement
+                'begin': '(?i)^\\s*(generic)\\b'
+                'beginCaptures':
+                  '1': 'name': 'support.function.generic.type-bound.fortran.modern'
+                'end': '(?=[;!\\n])'
+                'patterns':[
+                  {# attribute list
+                    'comment': 'derived-type attribute list'
+                    'begin': '(?i)(?<=generic)'
+                    'end': '(?i)(::)|(?=[a-z]|[;!\\n])'
+                    'endCaptures':
+                      '1': 'name': 'keyword.operator.double-colon.fortran'
+                    'patterns': [
+                      {
+                        'begin': '(?i)(,)'
+                        'beginCaptures':
+                          '1': 'name': 'punctuation.comma.fortran'
+                        'end': '(?=::|[,;!\\n])'
+                        'patterns':[
+                          {'include': '#access-attributes'}
+                        ]
+                      }
+                    ]
+                  }
+                  {# assignment
+                    'comment': 'type bound procedure binding name'
+                    'match': '(?i)(?<=generic|::)\\s*\\b(assignment)\\s*\\(\\s*(\\=)\\s*\\)'
+                    'captures':
+                      '1': 'name': 'keyword.other.assignment.fortran.modern'
+                      '2': 'name': 'keyword.operator.fortran.modern'
+                  }
+                  {# operator
+                    'comment': 'type bound procedure binding name'
+                    'match': '(?i)(?<=generic|::)\\s*\\b(operator)\\s*\\(\\s*(\\.[a-z]*\\.|\\=\\=|\\>\\=|\\<\\=|\\/\\=|\\>|\\<)\\s*\\)'
+                    'captures':
+                      '1': 'name': 'keyword.other.assignment.fortran.modern'
+                      '2': 'name': 'keyword.operator.fortran.modern'
+                  }
+                  {# binding list
+                    'begin': '\\=\\>'
+                    'beginCaptures':
+                      '0': 'name': 'keyword.operator.pointer.fortran.modern'
+                    'end': '(?=[;!\\n])'
+                    'patterns':[
+                      {
+                        'name': 'entity.name.function.procedure.fortran.modern'
+                        'match': '(?i)\\b[a-z]\\w*\\b'
+                      }
+                    ]
+                  }
+                ]
+              }
+              {# procedure statement
+                'comment': 'type bound procedure statement'
+                'begin': '(?i)^\\s*(procedure)\\b(?:\\s*\\(([a-z]\\w*)\\))?'
+                'beginCaptures':
+                  '1': 'name': 'support.function.procedure.type-bound.fortran.modern'
+                  '2': 'name': 'entity.name.function.procedure.fortran.modern'
+                'end': '(?i)(?=[;!$\\n])'
+                'patterns':[
+                  {# attribute list
+                    'comment': 'derived-type attribute list'
+                    'begin': '(?i)(?<=procedure|\\))\\b(?!\\s*\\()'
+                    'end': '(?i)(::)|(?=[a-z]|[;!\\n])'
+                    'endCaptures':
+                      '1': 'name': 'keyword.operator.double-colon.fortran'
+                    'patterns': [
+                      {
+                        'begin': '(?i)(,)'
+                        'beginCaptures':
+                          '1': 'name': 'punctuation.comma.fortran'
+                        'end': '(?=::|[,;!\\n])'
+                        'patterns':[
+                          {'include': '#access-attributes'}
+                          {
+                            'match': '(?i)\\b(pass)\\b\\s*(?:\\(\\s*([a-z]\\w*)\\s*\\))?(?!([^;!\\n](?!::))*(nopass|pass))'
+                            'captures':
+                              '1': 'name': 'keyword.other.attribute.procedure.fortran.modern'
+                              '2': 'name': 'keyword.other.attribute.procedure.fortran.modern'
+                            'end': '(?=[,:;!\\n])'
+                          }
+                          {
+                            'name': 'keyword.other.attribute.procedure.fortran.modern'
+                            'match': '(?i)\\b(nopass)\\b(?!([^;!\\n](?!::))*(nopass|pass))'
+                          }
+                          {
+                            'name': 'keyword.other.attribute.procedure.fortran.modern'
+                            'match': '(?i)\\b(deferred|non_overridable)\\b(?!([^;!\\n](?!::))*(deferred|non_overridable))'
+                          }
+                          {
+                            'name': 'invalid.error.fortran'
+                            'match': '(?i)\\b\\w+\\b'
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                  {# binding name
+                    'comment': 'type bound procedure binding name'
+                    'match': '(?i)(?<=procedure|::)\\s*\\b([a-z]\\w*\\b)(?:\\s*(\\=\\>)(?:\\s*([a-z]\\w*\\b))?)?'
+                    'captures':
+                      '1': 'name': 'entity.name.function.procedure.fortran.modern'
+                      '2': 'name': 'keyword.other.operator.fortran.modern'
+                      '3': 'name': 'entity.name.function.procedure.fortran.modern'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
 
 'scopeName': 'source.fortran.modern'

--- a/grammars/fortran - punchcard.cson
+++ b/grammars/fortran - punchcard.cson
@@ -73,9 +73,6 @@
       {
         'include': '$self'
       }
-      {
-        'include': 'source.fortran.modern'
-      }
     ]
   }
   {
@@ -396,7 +393,7 @@
         'begin': '(?ix)\\b(backspace|close|format|endfile|inquire|open|
           read|rewind|write)\\s*\\('
         'beginCaptures':
-          '1': 'name': 'keyword.control.IO.fortran.modern'
+          '1': 'name': 'keyword.control.IO.fortran'
         'end': '\\)'
         'patterns':[
           {'include': '#procedure-call-dummy-variable'}


### PR DESCRIPTION
I had only intended to add more functions and subroutines to the language but in doing so I ran into a heap of new issues that in the end caused me to do some major overhaul of the Modern Fortran syntax. You'll notice the `patterns` section of the Modern Fortran syntax now is just

``` coffee-script
'patterns':[
  {
    'include': 'source.fortran'
  }
]
```

All of the rules previously kept in `patterns` have either been moved into the repository or to the new `injections` section. The `injections` section is kind of a weird thing so I'll try to explain as best I can. Previously, the Modern Fortran grammar imported all the rules from the Punchcard Fortran grammar from the `'include': 'source.fortran'` rule. However while this would import structures like `subroutine` and `function`, those structures wouldn't have the new Modern Fortran grammars inside of them. There was a sketchy "fix" for this issue in that the `subroutine` and `function` structures also included a reference to `'include': 'source.fortran.modern'` but this meant someone using only Punchcard Fortran would also always have access to the grammars defined in Modern Fortran. This fix also didn't address similar issues in other structures like `interface` or `module`.

The way the new `injection` rules work is that when the Modern Fortran grammar is loaded the Punchcard Fortran grammar is first loaded, then all the rules in the `injection` section are inserted into the loaded Punchcard Fortran grammar, finally the modified Punchcard Fortran grammar is loaded into the Modern Fortran grammar which is then applied to the source. This also gives greater flexibility in where rules can be applied. For instance it would be possible to highlight the `exit` statement only when it is embedded inside a `do` loop at some level, which could be quite useful.
