### PR TITLE
Fix for bug in do loops and if blocks introduced in previous merge. 

### DIFF
--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -25,6 +25,7 @@
       {'include': '#interface-blocks'}
       {'include': '#intrinsic-functions'}
       {'include': '#intrinsic-subroutines'}
+      {'include': '#control-constructs'}
       {
         'comment': 'Non-intrinsic subroutines.'
         'begin': '(?<=call|%)\\s+([a-z]\\w*)\\s*\\('
@@ -36,6 +37,7 @@
       }
       {'include': '#data-statements'}
       {'include': '#IO-statements'}
+      {'include': '#where-statement'}
       {
         'comment': 'Line of type specification'
         'name': 'meta.specification.fortran'
@@ -52,7 +54,6 @@
         'match': '(?i)(?:^|(?<=;))\\s*\\b(use)\\b'
         'name': 'keyword.control.fortran.modern'
       }
-      {'include': '#control-constructs'}
       {'include': '#intent-attributes'}
       {'include': '#type-attributes'}
       {'include': '#procedure-attributes'}
@@ -509,6 +510,12 @@
         ]
       }
     ]
+  'where-statement':
+    {
+      'comment': 'Single line where introduced in the Fortran 1990 standard.'
+      'match': '(?i)(?:^|(?<=;))\\s*\\b(where)\\b'
+      'name': 'keyword.control.fortran.modern'
+    }
   # definitions:
   'module-definition':
     'comment': 'Introduced in the Fortran 1990 standard.'
@@ -737,35 +744,104 @@
   # control constructs:
   'control-constructs':
     'patterns':[
-      {
-        'comment': 'Where construct. Introduced in the Fortran 1990 standard.'
-        'match': '(?i)(?:^|(?<=;))\\s*\\b(where|elsewhere|end\\s*where)\\b'
-        'name': 'keyword.control.fortran.modern'
-      }
-      {
-        'comment': 'Select case construct. Introduced in the Fortran 1990 standard.'
-        'match': '(?i)(?:^|(?<=;))\\s*\\b(select(?:\\s+(case))?(?!\\s+type)|case(\\s+default)?|end\\s+select)\\b'
-        'name': 'keyword.control.fortran.modern'
-      }
-      {
-        'comment': 'Forall construct. Introduced in the Fortran 1995 standard.'
-        'match': '(?i)(?:^|(?<=;))\\s*\\b((end\\s+)?forall)\\b'
-        'name': 'keyword.control.fortran.modern'
-      }
-      {
-        'comment': 'Associate construct. Introduced in the Fortran 2003 standard.'
-        'match': '(?i)(?:^|(?<=;))\\s*\\b((end)?\\s*associate)\\b'
-        'name': 'keyword.control.fortran.modern'
-      }
-      {
-        'comment': 'Select type construct. Introduced in the Fortran 2003 standard.'
-        'match': '(?i)(?:^|(?<=;))\\s*\\b(select(?:\\s+(type))?|(class|type)\\s+is|end\\s+select)\\b'
-        'name': 'keyword.control.fortran.modern'
-      }
+      {'include': '#associate-construct'}
+      {'include': '#forall-construct'}
+      {'include': '#select-case-construct'}
+      {'include': '#select-type-construct'}
+      {'include': '#where-construct'}
       {
         'comment': 'Do concurrent construct. Introduced in the Fortran 2008 standard.'
         'match': '(?i)\\b(?<=do)\\s+(concurrent)\\b'
         'name': 'keyword.control.fortran.modern'
       }
     ]
+  'associate-construct':
+    {
+      'comment': 'Introduced in the Fortran 2003 standard.'
+      'contentName': 'meta.associate.fortran'
+      'begin': '(?i)(?:^|(?<=;))\\s*(associate)\\b'
+      'beginCaptures':
+        '1': 'name': 'keyword.control.associate.fortran'
+      'end': '(?i)(?:^|(?<=;))\\s*(end\\s*associate)\\b\\s*(\\S.*)?(?=[;!\\n])'
+      'endCaptures':
+        '1': 'name': 'keyword.control.endassociate.fortran'
+        '2': 'name': 'invalid.error.fortran'
+      'patterns':[
+        {'include': '$self'}
+      ]
+    }
+  'forall-construct':
+    {
+      'comment': 'Introduced in the Fortran 1995 standard.'
+      'contentName': 'meta.forall.fortran'
+      'begin': '(?i)(?:^|(?<=;))\\s*(forall)\\b'
+      'beginCaptures':
+        '1': 'name': 'keyword.control.forall.fortran'
+      'end': '(?i)(?:^|(?<=;))\\s*(end\\s*forall)\\b\\s*(\\S.*)?(?=[;!\\n])'
+      'endCaptures':
+        '1': 'name': 'keyword.control.endforall.fortran'
+        '2': 'name': 'invalid.error.fortran'
+      'patterns':[
+        {'include': '$self'}
+      ]
+    }
+  'select-case-construct':
+    {
+      'comment': 'Introduced in the Fortran 1990 standard.'
+      'contentName': 'meta.select.case.fortran'
+      'begin': '(?i)(?:^|(?<=;))\\s*(select)\\s+(case)\\b'
+      'beginCaptures':
+        '1': 'name': 'keyword.control.select.fortran'
+        '2': 'name': 'keyword.control.case.fortran'
+      'end': '(?i)(?:^|(?<=;))\\s*(end\\s*select)\\b\\s*(\\S.*)?(?=[;!\\n])'
+      'endCaptures':
+        '1': 'name': 'keyword.control.endselect.fortran'
+        '2': 'name': 'invalid.error.fortran'
+      'patterns':[
+        {
+          'name': 'keyword.control.fortran.modern'
+          'match': '(?i)(?:^|(?<=;))\\s*case(\\s+default)?\\b'
+        }
+        {'include': '$self'}
+      ]
+    }
+  'select-type-construct':
+    {
+      'comment': 'Introduced in the Fortran 2003 standard.'
+      'contentName': 'meta.select.type.fortran'
+      'begin': '(?i)(?:^|(?<=;))\\s*(select)\\s+(type)\\b'
+      'beginCaptures':
+        '1': 'name': 'keyword.control.select.fortran'
+        '2': 'name': 'keyword.control.type.fortran'
+      'end': '(?i)(?:^|(?<=;))\\s*(end\\s*select)\\b\\s*(\\S.*)?(?=[;!\\n])'
+      'endCaptures':
+        '1': 'name': 'keyword.control.endselect.fortran'
+        '2': 'name': 'invalid.error.fortran'
+      'patterns':[
+        {
+          'name': 'keyword.control.fortran.modern'
+          'match': '(?i)(?:^|(?<=;))\\s*\\b(class|type)\\s+is\\b'
+        }
+        {'include': '$self'}
+      ]
+    }
+  'where-construct':
+    {
+      'comment': 'Introduced in the Fortran 1990 standard.'
+      'contentName': 'meta.where.fortran'
+      'begin': '(?i)(?:^|(?<=;))\\s*(where)\\b(?!\\s*\\(.*\\)\\s*[a-z])'
+      'beginCaptures':
+        '1': 'name': 'keyword.control.where.fortran'
+      'end': '(?i)(?:^|(?<=;))\\s*(end\\s*where)\\b\\s*(\\S.*)?(?=[;!\\n])'
+      'endCaptures':
+        '1': 'name': 'keyword.control.endwhere.fortran'
+        '2': 'name': 'invalid.error.fortran'
+      'patterns':[
+        {
+          'name': 'keyword.control.fortran.modern'
+          'match': '(?i)(?:^|(?<=;))\\s*\\b(else\\s*where)\\b'
+        }
+        {'include': '$self'}
+      ]
+    }
 'scopeName': 'source.fortran.modern'

--- a/grammars/fortran - punchcard.cson
+++ b/grammars/fortran - punchcard.cson
@@ -52,7 +52,7 @@
     'beginCaptures':
       '1': 'name': 'storage.type.function.fortran'
       '2': 'name': 'entity.name.function.fortran'
-    'end': '(?i)(end)(?!\\s*(?:do|if))(?:\\s*(\\1)(\\s+\\2)?\\b)?\\s*([^;!\\n]+)?'
+    'end': '(?i)(end)(?:\\s*(\\1)(\\s+\\2)?\\b)?\\s*([^;!\\n]+)?'
     'endCaptures':
       '1': 'name': 'keyword.other.fortran'
       '2': 'name': 'storage.type.function.fortran'
@@ -135,6 +135,15 @@
       '1': 'name': 'keyword.control.enddo.fortran'
       '2': 'name': 'invalid.error.fortran'
     'patterns':[
+      {
+        'begin': '(?i)\\G\\s*\\b(while)\\s*\\('
+        'beginCaptures':
+          '1': 'name': 'keyword.control.while.fortran'
+        'end': '(?:(\\))|(?=[;!\\n]))'
+        'patterns':[
+          {'include': '$self'}
+        ]
+      }
       {'include': '$self'}
     ]
   }
@@ -154,7 +163,7 @@
   }
   {
     'comment': 'statements controling the flow of the program'
-    'match': '\\b(?i:(go\\s*to|assign|to|if|then|else|elseif|end\\s*if|continue|stop|pause|while|cycle))\\b'
+    'match': '\\b(?i:(go\\s*to|assign|to|if|then|else|elseif|end\\s*if|continue|stop|pause|cycle))\\b'
     'name': 'keyword.control.fortran'
   }
   {


### PR DESCRIPTION
In my previous pull request there was a bug that I missed regarding multi-line constructs like `do`, `forall`, `select type`, etc..., where program end statements would consume and stop on their end statements instead of their own. This contains a fix for  these issues and introduced line continuation operators `&` into Modern Fortran.
