### PR TITLE
Fixes #19.

### DIFF
--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -20,7 +20,7 @@
     'patterns':[
       {'include': '#string-line-continuation'}
     ]
-  'source.fortran - ( string | comment )':
+  'source.fortran - ( string | comment | meta.line-continuation )':
     'patterns':[
       {'include': '#comments'}
       {'include': '#operators'}
@@ -160,7 +160,8 @@
     ]
   'line-continuation':
     'comment': 'Operator that allows a line to be continued on the next line.'
-    'begin': '(&)'
+    'contentName': 'meta.line-continuation.fortran.modern'
+    'begin': '\\s*(&)'
     'beginCaptures':
       '1': 'name': 'keyword.operator.line-continuation.fortran.modern'
     'end': '(?i)^(?:(?=\\s*[^\\s!&])|\\s*(&))'
@@ -170,7 +171,7 @@
       {'include': '#comments'}
       {
         'name': 'invalid.error.fortran.modern'
-        'match': '\\S.*'
+        'match': '\\S[^!]*'
       }
     ]
   'string-line-continuation':

--- a/grammars/fortran - punchcard.cson
+++ b/grammars/fortran - punchcard.cson
@@ -23,10 +23,10 @@
   {'include': '#subroutine-definition'}
   {'include': '#type-specifications'}
   {'include': '#do-construct'}
-  {'include': '#if-then-construct'}
+  {'include': '#if-construct'}
   {
     'comment': 'statements controling the flow of the program'
-    'match': '\\b(?i:(go\\s*to|assign|to|if|then|else|elseif|end\\s*if|continue|stop|pause))\\b'
+    'match': '\\b(?i:(go\\s*to|assign|to|continue|stop|pause))\\b'
     'name': 'keyword.control.fortran'
   }
   {
@@ -36,6 +36,7 @@
   }
   {'include': '#intrinsic-functions'}
   {'include': '#IO-statements'}
+  {'include': '#parentheses'}
   {
     'comment': 'data type attributes'
     'match': '\\b(?i:(dimension|common|equivalence|parameter|external|intrinsic|save|data|implicit\\s*none|implicit))\\b'
@@ -466,39 +467,51 @@
         {'include': '$self'}
       ]
     }
-  # 'if-construct':
-  #   {
-  #     'contentName': 'meta.if.fortran'
-  #     'begin': '(?i)(?:^|\\G(?<=:)|(?<=;))\\s*(if)\\b(?![^\\n]*\\bthen)\\b'
-  #     'beginCaptures':
-  #       '1': 'name': 'keyword.control.if.fortran'
-  #     'end': '(?i)(?=[;!\\n])'
-  #     'patterns':[
-  #       {
-  #         'begin': '\\G\\s*\\('
-  #         'end': '(?:\\)|(?=;!\\n))'
-  #         'patterns':[
-  #           {'include': '$self'}
-  #         ]
-  #       }
-  #       {
-  #         'begin': '(?<=\\)\\s*(call)\\b)'
-  #       }
-  #       {'include': '$self'}
-  #     ]
-  #   }
-  'if-then-construct':
+  'if-construct':
     {
-      'contentName': 'meta.if-then.fortran'
-      'begin': '(?i)(?:^|\\G(?<=:)|(?<=;))\\s*(if)\\b(?=[^\\n]*\\bthen)\\b'
+      'contentName': 'meta.if.fortran'
+      'begin': '(?i)(?:^|\\G(?<=:)|(?<=;))\\s*(if)\\b'
       'beginCaptures':
         '1': 'name': 'keyword.control.if.fortran'
-      'end': '(?i)(?:^|(?<=;))\\s*(end\\s*if)\\b'
-      'endCaptures':
-        '1': 'name': 'keyword.control.endif.fortran'
-        '2': 'name': 'invalid.error.fortran'
+      'end': '(?<!\\G)(?!\\s*&)'
+      'applyEndPatternLast': 1
       'patterns':[
-        {'include': '$self'}
+        {'include': '#parentheses'}
+        {
+          'contentName': 'meta.then.fortran'
+          'begin': '(?i)\\s*\\b(then)\\b'
+          'beginCaptures':
+            '1': 'name': 'keyword.control.then.fortran'
+          'end': '(?i)(?:^|(?<=;))\\s*(end\\s*if)\\b'
+          'endCaptures':
+            '1': 'name': 'keyword.control.endif.fortran'
+          'patterns':[
+            {
+              'begin': '(?i)(?:^|(?<=;))\\s*(else\\s*if)\\b'
+              'beginCaptures':
+                '1': 'name': 'keyword.control.elseif.fortran'
+              'end': '(?=[;!\\n])'
+              'patterns':[
+                {'include': '#parentheses'}
+                {
+                  'match': '\\s*\\b(then)\\b'
+                  'captures':
+                    '1': 'name': 'keyword.control.then.fortran'
+                }
+              ]
+            }
+            {
+              'begin': '(?i)(?:^|(?<=;))\\s*(else)\\b(?!\\s*if\\b)'
+              'beginCaptures':
+                '1': 'name': 'keyword.control.else.fortran'
+              'end': '(?i)(?=\\s*end\\s*if\\b)'
+              'patterns':[
+                {'include': '$self'}
+              ]
+            }
+            {'include': '$self'}
+          ]
+        }
       ]
     }
   # intrinsic procedures:
@@ -538,9 +551,6 @@
       }
     ]
   # other:
-  'procedure-call-dummy-variable':
-    'name': 'variable.parameter.dummy-variable.fortran'
-    'match': '(?i)\\b([a-z]\\w*)(?=\\s*\\=)'
   'dummy-variable-list':
     {
       'begin': '\\G\\s*(\\()'
@@ -556,6 +566,17 @@
           'captures':
             '1': 'name': 'variable.parameter.fortran'
         }
+      ]
+    }
+  'procedure-call-dummy-variable':
+    'name': 'variable.parameter.dummy-variable.fortran'
+    'match': '(?i)\\b([a-z]\\w*)(?=\\s*\\=)'
+  'parentheses':
+    {
+      'begin': '(?i)\\s*\\('
+      'end': '(?:\\)|(?=[;!\\n]))'
+      'patterns':[
+        {'include': '$self'}
       ]
     }
 'scopeName': 'source.fortran'


### PR DESCRIPTION
These changes should fix issue #19. The changes here can be broken down into two parts:

1. **Created a new general rule for matching parentheses:**
This will prevent other rules from terminating prematurely in the middle of a set of parentheses. In order to make the behavior while typing less obnoxious parentheses are only matched when they occur on the same line. However, structures like the line continuation statement, which consume the new-line character, override this feature allowing the parentheses structure to span into the next line.

2. **Reworked the if-construct rules to work with new multi-line conditional statements:**
The old rule for if-constructs determined if the line was an if-statement or an if-construct by whether or not the line ended with `then`. Since, as far as I know, look aheads can't span multiple lines the new rule is designed to terminate before the end of the line, however the `then` keyword stars a new *multi-line* rule that can only be terminated by an `endif` statement.

 I did a fair bit of testing and I didn't notice anything out of place. As always though, if anyone else wants to test it that would be greatly appreciated.
