### PR TITLE
Fixes issues #23 and #24

### DIFF
--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -64,9 +64,8 @@
       {'include': '#result-statement'}
     ]
 'patterns': [
-  {
-    'include': 'source.fortran'
-  }
+  # {'include': '#do-construct'}
+  {'include': 'source.fortran'}
 ]
 'repository':
   # attributes:
@@ -894,6 +893,7 @@
       {'include': '#associate-construct'}
       {'include': '#block-construct'}
       {'include': '#critical-construct'}
+      {'include': '#do-construct'}
       {'include': '#forall-construct'}
       {'include': '#select-case-construct'}
       {'include': '#select-type-construct'}
@@ -954,6 +954,58 @@
         {'include': '$self'}
       ]
     }
+  'do-construct':
+    'patterns':[
+      {
+        'comment': 'Introduced in the Fortran 1977 standard.'
+        'name': 'meta.do.labeled.fortran'
+        'begin': '(?i)(?:^|\\G(?<=:)|(?<=[;\\d]))\\s*(do)\\s+(\\d{1,5})\\b'
+        'beginCaptures':
+          '1': 'name': 'keyword.control.do.fortran'
+          '2': 'name': 'constant.numeric.fortran'
+        'end': '(?i)^(?=\\s*\\2\\b)'
+        'patterns':[
+          {'include': '#do-modifiers'}
+          {'include': '$self'}
+        ]
+      }
+      {
+        'comment': 'Introduced in the Fortran 1995 standard.'
+        'contentName': 'meta.do.unlabeled.fortran'
+        'begin': '(?i)(?:^|\\G(?<=:)|(?<=[;\\d]))\\s*(do)\\b(?!\\s+\\d)'
+        'beginCaptures':
+          '1': 'name': 'keyword.control.do.fortran'
+          '2': 'name': 'constant.numeric.fortran'
+        'end': '(?i)^\\s*(?:(continue)|(end\\s*do))\\b'
+        'endCaptures':
+          '1': 'name': 'keyword.control.continue.fortran'
+          '2': 'name': 'keyword.control.enddo.fortran'
+        'patterns':[
+          {'include': '#do-modifiers'}
+          {'include': '$self'}
+        ]
+      }
+      {
+        'comment': 'For matching enddo statements at then end of labeled do
+          constructs.'
+        'match': '(?i)(?<=\\d)\\b\\s+\\b(end\\s*do)\\b'
+        'captures':
+          '1': 'name': 'keyword.control.enddo.fortran'
+      }
+    ]
+  'do-modifiers':
+    'patterns':[
+      {
+        'comment': 'Introduced in the Fortran 2003 standard.'
+        'name': 'keyword.control.do.concurrent.fortran'
+        'match': '(?i)\\b(concurrent)\\b'
+      }
+      {
+        'comment': 'Introduced in the Fortran 1995 standard.'
+        'name': 'keyword.control.do.while.fortran'
+        'match': '(?i)\\b(while)\\b'
+      }
+    ]
   'forall-construct':
     {
       'comment': 'Introduced in the Fortran 1995 standard.'

--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -64,7 +64,6 @@
       {'include': '#result-statement'}
     ]
 'patterns': [
-  # {'include': '#do-construct'}
   {'include': 'source.fortran'}
 ]
 'repository':

--- a/grammars/fortran - punchcard.cson
+++ b/grammars/fortran - punchcard.cson
@@ -10,6 +10,11 @@
   'FPP'
 ]
 'name': 'Fortran - Punchcard'
+'injections':
+  'source.fortran - ( comments | string )':
+    'patterns':[
+      {'include': '#do-construct'}
+    ]
 'patterns': [
   {'include': '#preprocessor-rule-enabled'}
   {'include': '#preprocessor-rule-disabled'}
@@ -22,7 +27,6 @@
   {'include': '#program-definition'}
   {'include': '#subroutine-definition'}
   {'include': '#type-specifications'}
-  {'include': '#do-construct'}
   {'include': '#if-construct'}
   {
     'comment': 'statements controling the flow of the program'
@@ -445,28 +449,47 @@
     }
   # control constructs:
   'do-construct':
-    {
-      'contentName': 'meta.do.fortran'
-      'begin': '(?i)(?:^|\\G(?<=:)|(?<=;))\\s*(do)\\b'
-      'beginCaptures':
-        '1': 'name': 'keyword.control.do.fortran'
-      'end': '(?i)(?:^|(?<=;))\\s*(end\\s*do)\\b'
-      'endCaptures':
-        '1': 'name': 'keyword.control.enddo.fortran'
-        '2': 'name': 'invalid.error.fortran'
-      'patterns':[
-        {
-          'begin': '(?i)\\G\\s*\\b(while)\\s*\\('
-          'beginCaptures':
-            '1': 'name': 'keyword.control.while.fortran'
-          'end': '(?:(\\))|(?=[;!\\n]))'
-          'patterns':[
-            {'include': '$self'}
-          ]
-        }
-        {'include': '$self'}
-      ]
-    }
+    'patterns':[
+      {
+        'name': 'meta.do.labeled.fortran'
+        'begin': '(?i)(?:^|(?<=\\d))\\s*(do)\\s+(\\d{1,5})\\b'
+        'beginCaptures':
+          '1': 'name': 'keyword.control.do.fortran'
+          '2': 'name': 'constant.numeric.fortran'
+        'end': '(?i)^(?=\\s*\\2\\b)'
+        'patterns':[
+          {'include': '$self'}
+        ]
+      }
+      {
+        'match': '(?i)(?:^|(?<=\\d))\\s*\\b(do)\\b(?=\\s*[;!\\n])'
+        'captures':
+          '1': 'name': 'keyword.control.do.fortran'
+      }
+    ]
+  # 'do-construct':
+  #   {
+  #     'contentName': 'meta.do.fortran'
+  #     'begin': '(?i)(?:^|\\G(?<=:)|(?<=;))\\s*(do)\\b'
+  #     'beginCaptures':
+  #       '1': 'name': 'keyword.control.do.fortran'
+  #     'end': '(?i)(?:^|(?<=;))\\s*(end\\s*do)\\b'
+  #     'endCaptures':
+  #       '1': 'name': 'keyword.control.enddo.fortran'
+  #       '2': 'name': 'invalid.error.fortran'
+  #     'patterns':[
+  #       {
+  #         'begin': '(?i)\\G\\s*\\b(while)\\s*\\('
+  #         'beginCaptures':
+  #           '1': 'name': 'keyword.control.while.fortran'
+  #         'end': '(?:(\\))|(?=[;!\\n]))'
+  #         'patterns':[
+  #           {'include': '$self'}
+  #         ]
+  #       }
+  #       {'include': '$self'}
+  #     ]
+  #   }
   'if-construct':
     {
       'contentName': 'meta.if.fortran'


### PR DESCRIPTION
Issue #24 was the result of the problem outlined in issue #23. To fix these do-loops were split into two types: labeled do-loops, such as those used in Punchcard Fortran
```fortran
do 100 i = 1, 10
  ..
100 continue
```
and unlabeled do-loops, such as those commonly found in Modern Fortran
```fortran
do i = 1, 10
  ..
end do
```
I tested the changes on my own files as well as the source code posted by @elezar in issue #24.