### PR TITLE
Fixes #35

### DIFF
--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -2327,9 +2327,11 @@
     ]
   'attribute-specification-statement':
     'name': 'meta.statement.attribute-specification.fortran'
-    'begin': '(?ix)(?:^|(?<=;))(?=\\s*\\b(?:allocatable|asynchronous|bind
-      |codimension|contiguous|dimension|external|intent|intrinsic|optional
-      |parameter|pointer|private|protected|public|save|target|value|volatile)\\b)'
+    'begin': '(?ix)(?:^|(?<=;))(?=\\s*\\b(?:allocatable|asynchronous|contiguous
+      |external|intrinsic|optional|parameter|pointer|private|protected|public
+      |save|target|value|volatile)\\b
+      |(bind|dimension|intent)\\s*\\(
+      |(codimension)\\s*\\[)'
     'end': '(?=[;!\\n])'
     'patterns':[
       {'include': '#access-attribute'}


### PR DESCRIPTION
Issue #35 was being caused by type attributes statements with some form
of either parentheses or brackets following them. I'm not exactly sure
why this is but the issue is fixed by having the type attribute
statement look ahead only match these statements when their respective
parentheses or bracket is present.