### PR TITLE
Fixes #37

### DIFF
--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -2678,7 +2678,14 @@
     'begin': '(?i)(?=\\s*[a-z])'
     'end': '(?=[;!\\n])'
     'patterns': [
-      {'include': '$self'}
+      {'include': '#constants'}
+      {'include': '#line-continuation-operator'}
+      {'include': '#operators'}
+      {'include': '#intrinsic-functions'}
+      {'include': '#array-constructor'}
+      {'include': '#parentheses'}
+      {'include': '#brackets'}
+      # {'include': '$self'}
     ]
   'operator-keyword':
     'comment': 'Operator generic specification.'


### PR DESCRIPTION
Issue #37 was caused by including `$self` in the namelist rule set. This
allowed one of the other base language rules to force Atom into an
infinite loop of creating and then destroying type-specification-
statements blocks. To fix this the namelist rule set has been modified
to be more explicit as to which base rule sets are imported into it.