### PR TITLE
Remove activationEvents fix deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "main": "./lib/new-package",
   "version": "1.5.3",
   "description": "Syntax highlighting for FORTRAN in atom ",
-  "activationEvents": [
-    "language-fortran:toggle"
-  ],
   "repository": "https://github.com/dparkins/language-fortran",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
atom core (1 deprecation)
Use activationCommands instead of activationEvents in your package.json Commands should be grouped by selector as follows:

  "activationCommands": {
    "atom-workspace": ["foo:bar", "foo:baz"],
    "atom-text-editor": ["foo:quux"]
  }
Called 1 time
Package.getActivationCommands - /Applications/Atom.app/Contents/Resources/app.asar/src/package.js:776:9
Package.hasActivationCommands - /Applications/Atom.app/Contents/Resources/app.asar/src/package.js:701:20
<unknown> - /Applications/Atom.app/Contents/Resources/app.asar/src/package.js:169:24
Package.measure - /Applications/Atom.app/Contents/Resources/app.asar/src/package.js:147:15