### PR TITLE
Fixes #52

### DIFF
--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -277,25 +277,12 @@
         'end': '(?=\\n)'
       }
       {
-        'begin': '^[Cc](?=\\b|[Cc])'
+        'begin': '^[Cc\\*]'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.comment.fortran'
-        'end': '$\\n?'
+        'end': '(?=\\n)'
         'name': 'comment.line.c.fortran'
-        'patterns': [
-          {
-            'match': '\\\\\\s*\\n'
-          }
-        ]
-      }
-      {
-        'begin': '^\\*'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.fortran'
-        'end': '$\\n?'
-        'name': 'comment.line.asterisk.fortran'
         'patterns': [
           {
             'match': '\\\\\\s*\\n'

--- a/grammars/fortran - punchcard.cson
+++ b/grammars/fortran - punchcard.cson
@@ -30,25 +30,12 @@
   'comments':
     'patterns':[
       {
-        'begin': '^[Cc](?=\\b|[Cc])'
+        'begin': '^[Cc\\*]'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.comment.fortran'
-        'end': '$\\n?'
+        'end': '(?=\\n)'
         'name': 'comment.line.c.fortran'
-        'patterns': [
-          {
-            'match': '\\\\\\s*\\n'
-          }
-        ]
-      }
-      {
-        'begin': '^\\*'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.fortran'
-        'end': '$\\n?'
-        'name': 'comment.line.asterisk.fortran'
         'patterns': [
           {
             'match': '\\\\\\s*\\n'


### PR DESCRIPTION
Line comments starting with c or C in the first character position
weren't being recognized when immediately followed by another non-blank
character. This corrects this bug by allowing such comments to have any
character following the initial comment character.