### PR TITLE
Fixes #57

### DIFF
--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -711,6 +711,12 @@
           {'include': '#parentheses'}
         ]
       }
+      {
+        'comment': 'User defined subroutine.'
+        'match': '(?i)\\G\\s*\\b([a-z]\\w*)\\b(?=\\s*[;!\\n])'
+        'captures':
+          '1': 'name': 'entity.name.function.subroutine.fortran'
+      }
       {'include': '$base'}
     ]
   'continue-statement':

--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -726,6 +726,12 @@
           {'include': '$self'}
         ]
       }
+      {
+        'comment': 'User defined subroutine.'
+        'match': '(?i)\\G\\s*\\b([a-z]\\w*)\\b(?=\\s*[;!\\n])'
+        'captures':
+          '1': 'name': 'entity.name.function.subroutine.fortran'
+      }
       {'include': '$self'}
     ]
   'continue-statement':


### PR DESCRIPTION
Subroutines with no dummy variables were not being highlighted correctly
when no parentheses were present as in

call subroutineName

This is inconsistent with the current Fortran standard and has therefore
been corrected in Fortran - Fixed Form, Fortran - Free Form, and
Fortran - Modern.