### PR TITLE
Fixes #62

### DIFF
--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -964,6 +964,7 @@
     'end': '(?=[;!\\n])'
     'patterns':[
       {'include': '#types'}
+      {'include': '#line-continuation-operator'}
       {
         'comment': 'Attribute list.'
         'contentName': 'meta.attribute-list.fortran'

--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -996,6 +996,7 @@
     'end': '(?=[;!\\n])'
     'patterns':[
       {'include': '#types'}
+      {'include': '#line-continuation-operator'}
       {
         'comment': 'Attribute list.'
         'contentName': 'meta.attribute-list.fortran'


### PR DESCRIPTION
Line continuation operators weren't working in type definition statements inside derived type definition constructs when no variable names were given. This commit fixes this issue bringing derived type type definitions in line with those in other scopes.