### PR TITLE
Fixes #64

### DIFF
--- a/settings/language-fortran.cson
+++ b/settings/language-fortran.cson
@@ -18,7 +18,7 @@
     'commentEnd': ''
     'increaseIndentPattern': '(?ix)^\\s*(
         (block\\s*data|contains|program|submodule)\\b
-        |((?!end\\b).)*\\b(function|subroutine)\\b
+        |((?!end\\b)[^\'"!])*\\b(function|subroutine)\\b
         |module\\b(?!\\s+procedure\\b)
         |type(?!\\s*\\()
         |(abstract\\s+)?interface\\b


### PR DESCRIPTION
Changed the regex for auto-indenting after the first line in a function/subroutine definition to not trigger when the word function or subroutine is used in a string/comment.