### PR TITLE
Fixes #70

### DIFF
--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -846,7 +846,7 @@
   # derived type definition:
   'derived-type-definition':
     'name': 'meta.derived-type.definition.fortran'
-    'begin': '(?i)\\b(type)\\b(?!\\s*(\\(|is\\b))'
+    'begin': '(?i)\\b(type)\\b(?!\\s*(\\(|is\\b|\\=))'
     'beginCaptures':
       '1': 'name': 'keyword.control.type.fortran'
     'end': '(?=[;!\\n])'

--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -872,7 +872,7 @@
   # derived type definition:
   'derived-type-definition':
     'name': 'meta.derived-type.definition.fortran'
-    'begin': '(?i)(?:^|(?<=;))\\s*(type)\\b(?!\\s*(\\(|is\\b))'
+    'begin': '(?i)(?:^|(?<=;))\\s*(type)\\b(?!\\s*(\\(|is\\b|\\=))'
     'beginCaptures':
       '1': 'name': 'keyword.control.type.fortran'
     'end': '(?=[;!\\n])'

--- a/settings/language-fortran.cson
+++ b/settings/language-fortran.cson
@@ -20,7 +20,7 @@
         (block\\s*data|contains|program|submodule)\\b
         |((?!end\\b)[^\'"!])*\\b(function|subroutine)\\b
         |module\\b(?!\\s+procedure\\b)
-        |type(?!\\s*\\()
+        |type(?!\\s*(\\(|\\=))
         |(abstract\\s+)?interface\\b
         |([a-z]\\w*\\s*:\\s*)?(
           (associate|block|critical|do|forall)\\b


### PR DESCRIPTION
Variabled named "type" on the LHS of assignment statement statements were being flagged at derived type definition statement. This is fixed in this commit. It also adjusts the auto indentation rules to not indent after these lines as well.