### PR TITLE
Adds new functions to address #78

### DIFF
--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -65,7 +65,7 @@
     ]
   'allocatable-attribute':
     'comment': 'Introduced in the Fortran 1990 standard.'
-    'match': '(?i)\\G\\s*\\b(allocatable)\\b'
+    'match': '(?i)\\s*\\b(allocatable)\\b'
     'captures':
       '1': 'name': 'storage.modifier.allocatable.fortran'
   'asynchronous-attribute':

--- a/keymaps/language-fortran.cson
+++ b/keymaps/language-fortran.cson
@@ -1,0 +1,11 @@
+# Keybindings require three things to be fully defined: A selector that is
+# matched against the focused element, the keystroke and the command to
+# execute.
+#
+# Below is a basic keybinding which registers on all platforms by applying to
+# the root workspace element.
+
+# For more detailed documentation see
+# https://atom.io/docs/latest/behind-atom-keymaps-in-depth
+# 'atom-text-editor':
+#   'ctrl-alt-a': 'language-fortran:toggleComment'

--- a/lib/language-fortran.coffee
+++ b/lib/language-fortran.coffee
@@ -1,0 +1,60 @@
+{CompositeDisposable, Point, Range} = require 'atom'
+
+module.exports =
+  subscriptions: null
+
+  activate: ->
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'language-fortran:toggleComment': => @toggleComment()
+
+  deactivate: ->
+    @subscriptions.dispose()
+
+  # toggles comments on and off for each selected line in the active buffer
+  toggleComment: ->
+    commentToken = "C"
+    if editor = atom.workspace.getActiveTextEditor()
+      if editor.getGrammar().scopeName is 'source.fortran.fixed'
+        if buffer = editor.getBuffer()
+          for selection in editor.getSelections()
+            range = selection.getBufferRange()
+            start = range.start
+            end = range.end
+            startRow = start.row
+            endRow = end.row
+            for row in [startRow..endRow]
+              if @isCommentLine(row)
+                @removeCommentToken(buffer, row, commentToken)
+              else
+                @addCommentToken(buffer, row, commentToken)
+
+  # add a comment token to the start of the given row
+  addCommentToken: (buffer, row, token) ->
+    rowText = buffer.lineForRow(row)
+    rowTextLength = rowText.length
+    replaceText = token + rowText
+    range = [[row, 0], [row, rowTextLength]]
+    buffer.setTextInRange(range, replaceText)
+
+  # removes characters equal to the token length from the start of the given row
+  removeCommentToken: (buffer, row, token) ->
+    tokenLength = token.length
+    rowText = buffer.lineForRow(row)
+    rowTextLength = rowText.length
+    replaceText = rowText.substring(tokenLength)
+    range = [[row, 0], [row, rowTextLength]]
+    buffer.setTextInRange(range, replaceText)
+
+  # determines if the line containing the given point is a commented line.
+  isCommentLine: (row) ->
+    isCommented = false
+    point = [row,0]
+    editor = atom.workspace.getActiveTextEditor()
+    scopes = editor.scopeDescriptorForBufferPosition(point).getScopesArray()
+    if scopes.length > 1
+      for scope in scopes
+        if scope.match(/comment/g)
+          isCommented = true
+          return isCommented
+    return isCommented

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "language-fortran",
-  "main": "./lib/new-package",
+  "main": "./lib/language-fortran",
   "version": "2.0.9",
-  "description": "Syntax highlighting for FORTRAN in atom ",
+  "description": "Syntax highlighting for Fortran in atom ",
+  "activationCommands": {
+    "atom-workspace": "language-fortran:toggleComment"
+  },
   "repository": "https://github.com/dparkins/language-fortran",
   "bugs": "https://github.com/dparkins/language-fortran/issues",
   "license": "MIT",
@@ -12,6 +15,5 @@
   "keywords": [
     "grammar",
     "fortran"
-  ],
-  "dependencies": {}
+  ]
 }


### PR DESCRIPTION
Toggling comments in Fortran - Fixed Form files would place the comment character before the first non-blank character of the line. This is not helpful as Fortran - Fixed Form requires comment characters to be placed in the first character position of a given line. This commit does not fix this issue but it adds functions that will be used to fix it in a future commit.

The remaining step after this is to figure out how to make it so the toggle comment keybinding is only overridden in Fortran - Fixed Form files.