### PR TITLE
Fixes #78

### DIFF
--- a/keymaps/language-fortran.cson
+++ b/keymaps/language-fortran.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
-# 'atom-text-editor':
-#   'ctrl-alt-a': 'language-fortran:toggleComment'
+".editor[data-grammar='source fortran fixed']:not([mini])":
+  'cmd-/': 'language-fortran:toggleComment'


### PR DESCRIPTION
The new custom line comment function is now bound to `cmd-/` but only in `Fortran - Fixed Form` files.