### PR TITLE
Fixes #85

### DIFF
--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -1887,6 +1887,7 @@
                 'patterns':[
                   {'include': '#dummy-variable-list'}
                   {'include': '#result-statement'}
+                  {'include': '#language-binding-attribute'}
                 ]
               }
               {
@@ -2055,6 +2056,7 @@
                 'end': '(?=[;!\\n])'
                 'patterns':[
                   {'include': '#dummy-variable-list'}
+                  {'include': '#language-binding-attribute'}
                 ]
               }
               {


### PR DESCRIPTION
This extends the highlighting of language binding statements to subroutine and function definitions, consistent with more recent Fortran standards.