### PR TITLE
Add submodule snippet

### DIFF
--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -2032,57 +2032,49 @@
   'procedure-definition':
     'comment': 'Procedure program unit. Introduced in the Fortran 2008 standard.'
     'name': 'meta.procedure.fortran'
-    'begin': '(?i)(?:^|(?<=;))(?=[^\'";!\\n]*\\bmodule\\s+procedure\\b)'
+    'begin': '(?i)(?=[^\'";!\\n]*\\bmodule\\s+procedure\\b)'
     'end': '(?=[;!\\n])'
     'patterns':[
       {
-        'begin': '(?i)\\s*\\b(module\\s+procedure)\\b'
+        'comment': 'Procedure body.'
+        'begin': '(?i)\\G\\s*\\b([a-z]\\w*)\\b'
         'beginCaptures':
-          '1': 'name': 'keyword.other.procedure.fortran'
-        'end': '(?=[;!\\n])'
-        'patterns':[
+        '1': 'name': 'entity.name.function.procedure.fortran'
+        'end': '(?ix)\\s*\\b(?:(end\\s*procedure)(?:\\s+(\\1))?|(end))\\b
+        \\s*([^;!\\n]+)?(?=[;!\\n])'
+        'endCaptures':
+        '1': 'name': 'keyword.other.endprocedure.fortran'
+        '2': 'name': 'entity.name.function.procedure.fortran'
+        '3': 'name': 'keyword.other.endprocedure.fortran'
+        '4': 'name': 'invalid.error.fortran'
+        'patterns': [
           {
-            'comment': 'Procedure body.'
-            'begin': '(?i)\\G\\s*\\b([a-z]\\w*)\\b'
+            'comment': 'Rest of the first line in procedure construct - should be empty.'
+            'name': 'meta.first-line.fortran'
+            'begin': '\\G(?!\\s*[;!\\n])'
+            'end': '(?=[;!\\n])'
+            'patterns':[
+              {'include': '#invalid-character'}
+            ]
+          }
+          {
+            'comment': 'Specification and execution block.'
+            'name': 'meta.block.specification.fortran'
+            'begin': '(?i)(?!\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
+            'end': '(?i)(?=\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
+            'patterns':[
+              {'include': '$self'}
+            ]
+          }
+          {
+            'comment': 'Contains block.'
+            'name': 'meta.block.contains.fortran'
+            'begin': '(?i)\\s*(contains)\\b'
             'beginCaptures':
-              '1': 'name': 'entity.name.function.procedure.fortran'
-            'end': '(?ix)\\s*\\b(?:(end\\s*procedure)(?:\\s+(\\1))?|(end))\\b
-              \\s*([^;!\\n]+)?(?=[;!\\n])'
-            'endCaptures':
-              '1': 'name': 'keyword.other.endprocedure.fortran'
-              '2': 'name': 'entity.name.function.procedure.fortran'
-              '3': 'name': 'keyword.other.endprocedure.fortran'
-              '4': 'name': 'invalid.error.fortran'
-            'patterns': [
-              {
-                'comment': 'Rest of the first line in procedure construct - should be empty.'
-                'name': 'meta.first-line.fortran'
-                'begin': '\\G(?!\\s*[;!\\n])'
-                'end': '(?=[;!\\n])'
-                'patterns':[
-                  {'include': '#invalid-character'}
-                ]
-              }
-              {
-                'comment': 'Specification and execution block.'
-                'name': 'meta.block.specification.fortran'
-                'begin': '(?i)(?!\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
-                'end': '(?i)(?=\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
-                'patterns':[
-                  {'include': '$self'}
-                ]
-              }
-              {
-                'comment': 'Contains block.'
-                'name': 'meta.block.contains.fortran'
-                'begin': '(?i)\\s*(contains)\\b'
-                'beginCaptures':
-                  '1': 'name': 'keyword.control.contains.fortran'
-                'end': '(?i)(?=\\s*(?:end\\s*[;!\\n]|end\\s*procedure\\b))'
-                'patterns':[
-                  {'include': '$self'}
-                ]
-              }
+            '1': 'name': 'keyword.control.contains.fortran'
+            'end': '(?i)(?=\\s*(?:end\\s*[;!\\n]|end\\s*procedure\\b))'
+            'patterns':[
+              {'include': '$self'}
             ]
           }
         ]

--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -2036,45 +2036,53 @@
     'end': '(?=[;!\\n])'
     'patterns':[
       {
-        'comment': 'Procedure body.'
-        'begin': '(?i)\\G\\s*\\b([a-z]\\w*)\\b'
+        'begin': '(?i)\\s*\\b(module\\s+procedure)\\b'
         'beginCaptures':
-        '1': 'name': 'entity.name.function.procedure.fortran'
-        'end': '(?ix)\\s*\\b(?:(end\\s*procedure)(?:\\s+(\\1))?|(end))\\b
-        \\s*([^;!\\n]+)?(?=[;!\\n])'
-        'endCaptures':
-        '1': 'name': 'keyword.other.endprocedure.fortran'
-        '2': 'name': 'entity.name.function.procedure.fortran'
-        '3': 'name': 'keyword.other.endprocedure.fortran'
-        '4': 'name': 'invalid.error.fortran'
-        'patterns': [
+          '1': 'name': 'keyword.other.procedure.fortran'
+        'end': '(?=[;!\\n])'
+        'patterns':[
           {
-            'comment': 'Rest of the first line in procedure construct - should be empty.'
-            'name': 'meta.first-line.fortran'
-            'begin': '\\G(?!\\s*[;!\\n])'
-            'end': '(?=[;!\\n])'
-            'patterns':[
-              {'include': '#invalid-character'}
-            ]
-          }
-          {
-            'comment': 'Specification and execution block.'
-            'name': 'meta.block.specification.fortran'
-            'begin': '(?i)(?!\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
-            'end': '(?i)(?=\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
-            'patterns':[
-              {'include': '$self'}
-            ]
-          }
-          {
-            'comment': 'Contains block.'
-            'name': 'meta.block.contains.fortran'
-            'begin': '(?i)\\s*(contains)\\b'
+            'comment': 'Procedure body.'
+            'begin': '(?i)\\G\\s*\\b([a-z]\\w*)\\b'
             'beginCaptures':
-            '1': 'name': 'keyword.control.contains.fortran'
-            'end': '(?i)(?=\\s*(?:end\\s*[;!\\n]|end\\s*procedure\\b))'
-            'patterns':[
-              {'include': '$self'}
+              '1': 'name': 'entity.name.function.procedure.fortran'
+            'end': '(?ix)\\s*\\b(?:(end\\s*procedure)(?:\\s+(\\1))?|(end))\\b
+              \\s*([^;!\\n]+)?(?=[;!\\n])'
+            'endCaptures':
+              '1': 'name': 'keyword.other.endprocedure.fortran'
+              '2': 'name': 'entity.name.function.procedure.fortran'
+              '3': 'name': 'keyword.other.endprocedure.fortran'
+              '4': 'name': 'invalid.error.fortran'
+            'patterns': [
+              {
+                'comment': 'Rest of the first line in procedure construct - should be empty.'
+                'name': 'meta.first-line.fortran'
+                'begin': '\\G(?!\\s*[;!\\n])'
+                'end': '(?=[;!\\n])'
+                'patterns':[
+                  {'include': '#invalid-character'}
+                ]
+              }
+              {
+                'comment': 'Specification and execution block.'
+                'name': 'meta.block.specification.fortran'
+                'begin': '(?i)(?!\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'end': '(?i)(?=\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'patterns':[
+                  {'include': '$self'}
+                ]
+              }
+              {
+                'comment': 'Contains block.'
+                'name': 'meta.block.contains.fortran'
+                'begin': '(?i)\\s*(contains)\\b'
+                'beginCaptures':
+                  '1': 'name': 'keyword.control.contains.fortran'
+                'end': '(?i)(?=\\s*(?:end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'patterns':[
+                  {'include': '$self'}
+                ]
+              }
             ]
           }
         ]

--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -2032,25 +2032,11 @@
   'procedure-definition':
     'comment': 'Procedure program unit. Introduced in the Fortran 2008 standard.'
     'name': 'meta.procedure.fortran'
-    'begin': '(?i)(?:^|(?<=;))(?=[^\'";!\\n]*\\bprocedure\\b)'
+    'begin': '(?i)(?:^|(?<=;))(?=[^\'";!\\n]*\\bmodule\\s+procedure\\b)'
     'end': '(?=[;!\\n])'
     'patterns':[
       {
-        'comment': 'Attribute list.'
-        'name': 'meta.attribute-list.fortran'
-        'begin': '(?i)(?=\\G\\s*(?!\\bprocedure\\b))'
-        'end': '(?i)(?=\\bprocedure\\b)'
-        'patterns':[
-          {'include': '#elemental-attribute'}
-          {'include': '#module-attribute'}
-          {'include': '#pure-attribute'}
-          {'include': '#recursive-attribute'}
-          {'include': '#line-continuation-operator'}
-          {'include': '#invalid-word'}
-        ]
-      }
-      {
-        'begin': '(?i)\\s*\\b(procedure)\\b'
+        'begin': '(?i)\\s*\\b(module\\s+procedure)\\b'
         'beginCaptures':
           '1': 'name': 'keyword.other.procedure.fortran'
         'end': '(?=[;!\\n])'

--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -2182,10 +2182,11 @@
     'end': '(?=[;!\\n])'
     'patterns':[
       {
-        'begin': '(?i)\\G\\s*\\b(submodule)\\s*(\\()'
+        'begin': '(?i)\\G\\s*\\b(submodule)\\s*(\\()\\s*(\\w+)'
         'beginCaptures':
           '1': 'name': 'keyword.other.submodule.fortran'
           '2': 'name': 'punctuation.parentheses.left.fortran'
+          '3': 'name': 'entity.name.module.fortran'
         'end': '(\\))'
         'endCaptures':
           '1': 'name': 'punctuation.parentheses.left.fortran'
@@ -2197,12 +2198,12 @@
         'comment': 'Submodule body.'
         'begin': '(?i)\\s*\\b([a-z]\\w*)\\b'
         'beginCaptures':
-          '1': 'name': 'entity.name.submodule.fortran'
+          '1': 'name': 'entity.name.module.submodule.fortran'
         'end': '(?ix)\\s*\\b(?:(end\\s*submodule)(?:\\s+(\\1))?|(end))\\b
           \\s*([^;!\\n]+)?(?=[;!\\n])'
         'endCaptures':
           '1': 'name': 'keyword.other.endsubmodule.fortran'
-          '2': 'name': 'entity.name.submodule.fortran'
+          '2': 'name': 'entity.name.module.submodule.fortran'
           '3': 'name': 'keyword.other.endsubmodule.fortran'
           '4': 'name': 'invalid.error.fortran'
         'applyEndPatternLast': 1

--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -39,6 +39,7 @@
   {'include': '#program-definition'}
   {'include': '#submodule-definition'}
   {'include': '#subroutine-definition'}
+  {'include': '#procedure-definition'}
   {'include': '#derived-type-definition'}
   {'include': '#enum-block-construct'}
   {'include': '#interface-block-constructs'}
@@ -2023,6 +2024,79 @@
                 ]
               }
               {'include': '$base'}
+            ]
+          }
+        ]
+      }
+    ]
+  'procedure-definition':
+    'comment': 'Procedure program unit. Introduced in the Fortran 2008 standard.'
+    'name': 'meta.procedure.fortran'
+    'begin': '(?i)(?:^|(?<=;))(?=[^\'";!\\n]*\\bprocedure\\b)'
+    'end': '(?=[;!\\n])'
+    'patterns':[
+      {
+        'comment': 'Attribute list.'
+        'name': 'meta.attribute-list.fortran'
+        'begin': '(?i)(?=\\G\\s*(?!\\bprocedure\\b))'
+        'end': '(?i)(?=\\bprocedure\\b)'
+        'patterns':[
+          {'include': '#elemental-attribute'}
+          {'include': '#module-attribute'}
+          {'include': '#pure-attribute'}
+          {'include': '#recursive-attribute'}
+          {'include': '#line-continuation-operator'}
+          {'include': '#invalid-word'}
+        ]
+      }
+      {
+        'begin': '(?i)\\s*\\b(procedure)\\b'
+        'beginCaptures':
+          '1': 'name': 'keyword.other.procedure.fortran'
+        'end': '(?=[;!\\n])'
+        'patterns':[
+          {
+            'comment': 'Procedure body.'
+            'begin': '(?i)\\G\\s*\\b([a-z]\\w*)\\b'
+            'beginCaptures':
+              '1': 'name': 'entity.name.function.procedure.fortran'
+            'end': '(?ix)\\s*\\b(?:(end\\s*procedure)(?:\\s+(\\1))?|(end))\\b
+              \\s*([^;!\\n]+)?(?=[;!\\n])'
+            'endCaptures':
+              '1': 'name': 'keyword.other.endprocedure.fortran'
+              '2': 'name': 'entity.name.function.procedure.fortran'
+              '3': 'name': 'keyword.other.endprocedure.fortran'
+              '4': 'name': 'invalid.error.fortran'
+            'patterns': [
+              {
+                'comment': 'Rest of the first line in procedure construct.'
+                'name': 'meta.first-line.fortran'
+                'begin': '\\G(?!\\s*[;!\\n])'
+                'end': '(?=[;!\\n])'
+                'patterns':[
+                  {'include': '#invalid-word'}
+                ]
+              }
+              {
+                'comment': 'Specification and execution block.'
+                'name': 'meta.block.specification.fortran'
+                'begin': '(?i)(?!\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'end': '(?i)(?=\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'patterns':[
+                  {'include': '$self'}
+                ]
+              }
+              {
+                'comment': 'Contains block.'
+                'name': 'meta.block.contains.fortran'
+                'begin': '(?i)\\s*(contains)\\b'
+                'beginCaptures':
+                  '1': 'name': 'keyword.control.contains.fortran'
+                'end': '(?i)(?=\\s*(?:end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'patterns':[
+                  {'include': '$self'}
+                ]
+              }
             ]
           }
         ]

--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -2069,12 +2069,12 @@
               '4': 'name': 'invalid.error.fortran'
             'patterns': [
               {
-                'comment': 'Rest of the first line in procedure construct.'
+                'comment': 'Rest of the first line in procedure construct - should be empty.'
                 'name': 'meta.first-line.fortran'
                 'begin': '\\G(?!\\s*[;!\\n])'
                 'end': '(?=[;!\\n])'
                 'patterns':[
-                  {'include': '#invalid-word'}
+                  {'include': '#invalid-character'}
                 ]
               }
               {

--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -2249,10 +2249,11 @@
     'end': '(?=[;!\\n])'
     'patterns':[
       {
-        'begin': '(?i)\\G\\s*\\b(submodule)\\s*(\\()'
+        'begin': '(?i)\\G\\s*\\b(submodule)\\s*(\\()\\s*(\\w+)'
         'beginCaptures':
           '1': 'name': 'keyword.other.submodule.fortran'
           '2': 'name': 'punctuation.parentheses.left.fortran'
+          '3': 'name': 'entity.name.module.fortran'
         'end': '(\\))|(?=[;!\\n])'
         'endCaptures':
           '1': 'name': 'punctuation.parentheses.left.fortran'
@@ -2264,12 +2265,12 @@
         'comment': 'Submodule body.'
         'begin': '(?i)\\s*\\b([a-z]\\w*)\\b'
         'beginCaptures':
-          '1': 'name': 'entity.name.submodule.fortran'
+          '1': 'name': 'entity.name.module.submodule.fortran'
         'end': '(?ix)\\s*\\b(?:(end\\s*submodule)(?:\\s+(\\1))?|(end))\\b
           \\s*([^;!\\n]+)?(?=[;!\\n])'
         'endCaptures':
           '1': 'name': 'keyword.other.endsubmodule.fortran'
-          '2': 'name': 'entity.name.submodule.fortran'
+          '2': 'name': 'entity.name.module.submodule.fortran'
           '3': 'name': 'keyword.other.endsubmodule.fortran'
           '4': 'name': 'invalid.error.fortran'
         'applyEndPatternLast': 1

--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -17,6 +17,7 @@
   {'include': '#module-definition'}
   {'include': '#program-definition'}
   {'include': '#submodule-definition'}
+  {'include': '#procedure-definition'}
   {'include': '#subroutine-definition'}
   {'include': '#derived-type-definition'}
   {'include': '#enum-block-construct'}
@@ -2090,6 +2091,79 @@
             'end': '(?i)(?=\\s*(?:end\\s*[;!\\n]|end\\s*program\\b))'
             'patterns':[
               {'include': '$self'}
+            ]
+          }
+        ]
+      }
+    ]
+  'procedure-definition':
+    'comment': 'Procedure program unit. Introduced in the Fortran 2008 standard.'
+    'name': 'meta.procedure.fortran'
+    'begin': '(?i)(?:^|(?<=;))(?=[^\'";!\\n]*\\bprocedure\\b)'
+    'end': '(?=[;!\\n])'
+    'patterns':[
+      {
+        'comment': 'Attribute list.'
+        'name': 'meta.attribute-list.fortran'
+        'begin': '(?i)(?=\\G\\s*(?!\\bprocedure\\b))'
+        'end': '(?i)(?=\\bprocedure\\b)'
+        'patterns':[
+          {'include': '#elemental-attribute'}
+          {'include': '#module-attribute'}
+          {'include': '#pure-attribute'}
+          {'include': '#recursive-attribute'}
+          {'include': '#line-continuation-operator'}
+          {'include': '#invalid-word'}
+        ]
+      }
+      {
+        'begin': '(?i)\\s*\\b(procedure)\\b'
+        'beginCaptures':
+          '1': 'name': 'keyword.other.procedure.fortran'
+        'end': '(?=[;!\\n])'
+        'patterns':[
+          {
+            'comment': 'Procedure body.'
+            'begin': '(?i)\\G\\s*\\b([a-z]\\w*)\\b'
+            'beginCaptures':
+              '1': 'name': 'entity.name.function.procedure.fortran'
+            'end': '(?ix)\\s*\\b(?:(end\\s*procedure)(?:\\s+(\\1))?|(end))\\b
+              \\s*([^;!\\n]+)?(?=[;!\\n])'
+            'endCaptures':
+              '1': 'name': 'keyword.other.endprocedure.fortran'
+              '2': 'name': 'entity.name.function.procedure.fortran'
+              '3': 'name': 'keyword.other.endprocedure.fortran'
+              '4': 'name': 'invalid.error.fortran'
+            'patterns': [
+              {
+                'comment': 'Rest of the first line in procedure construct.'
+                'name': 'meta.first-line.fortran'
+                'begin': '\\G(?!\\s*[;!\\n])'
+                'end': '(?=[;!\\n])'
+                'patterns':[
+                  {'include': '#invalid-word'}
+                ]
+              }
+              {
+                'comment': 'Specification and execution block.'
+                'name': 'meta.block.specification.fortran'
+                'begin': '(?i)(?!\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'end': '(?i)(?=\\s*(?:contains\\b|end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'patterns':[
+                  {'include': '$self'}
+                ]
+              }
+              {
+                'comment': 'Contains block.'
+                'name': 'meta.block.contains.fortran'
+                'begin': '(?i)\\s*(contains)\\b'
+                'beginCaptures':
+                  '1': 'name': 'keyword.control.contains.fortran'
+                'end': '(?i)(?=\\s*(?:end\\s*[;!\\n]|end\\s*procedure\\b))'
+                'patterns':[
+                  {'include': '$self'}
+                ]
+              }
             ]
           }
         ]

--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -2136,12 +2136,12 @@
               '4': 'name': 'invalid.error.fortran'
             'patterns': [
               {
-                'comment': 'Rest of the first line in procedure construct.'
+                'comment': 'Rest of the first line in procedure construct - should be empty.'
                 'name': 'meta.first-line.fortran'
                 'begin': '\\G(?!\\s*[;!\\n])'
                 'end': '(?=[;!\\n])'
                 'patterns':[
-                  {'include': '#invalid-word'}
+                  {'include': '#invalid-character'}
                 ]
               }
               {

--- a/grammars/fortran - modern.cson
+++ b/grammars/fortran - modern.cson
@@ -2099,25 +2099,11 @@
   'procedure-definition':
     'comment': 'Procedure program unit. Introduced in the Fortran 2008 standard.'
     'name': 'meta.procedure.fortran'
-    'begin': '(?i)(?:^|(?<=;))(?=[^\'";!\\n]*\\bprocedure\\b)'
+    'begin': '(?i)(?:^|(?<=;))(?=[^\'";!\\n]*\\bmodule\\s+procedure\\b)'
     'end': '(?=[;!\\n])'
     'patterns':[
       {
-        'comment': 'Attribute list.'
-        'name': 'meta.attribute-list.fortran'
-        'begin': '(?i)(?=\\G\\s*(?!\\bprocedure\\b))'
-        'end': '(?i)(?=\\bprocedure\\b)'
-        'patterns':[
-          {'include': '#elemental-attribute'}
-          {'include': '#module-attribute'}
-          {'include': '#pure-attribute'}
-          {'include': '#recursive-attribute'}
-          {'include': '#line-continuation-operator'}
-          {'include': '#invalid-word'}
-        ]
-      }
-      {
-        'begin': '(?i)\\s*\\b(procedure)\\b'
+        'begin': '(?i)\\s*\\b(module\\s+procedure)\\b'
         'beginCaptures':
           '1': 'name': 'keyword.other.procedure.fortran'
         'end': '(?=[;!\\n])'

--- a/settings/language-fortran.cson
+++ b/settings/language-fortran.cson
@@ -19,7 +19,7 @@
     'increaseIndentPattern': '(?ix)^\\s*(
         (block\\s*data|contains|program|submodule)\\b
         |((?!end\\b)[^\'"!])*\\b(function|subroutine)\\b
-        |module\\b(?!\\s+procedure\\b)
+        |module\\b
         |type(?!\\s*(\\(|\\=))
         |(abstract\\s+)?interface\\b
         |([a-z]\\w*\\s*:\\s*)?(
@@ -37,7 +37,7 @@
         |(class|type)\\s+is\\b
         |end(
           do|forall|function|if|interface|module|program
-          |select|submodule|subroutine|type|where
+          |select|submodule|subroutine|type|where|procedure
         )?\\b
         |else(if|where)?\\b
       )'

--- a/snippets/language-fortran.cson
+++ b/snippets/language-fortran.cson
@@ -242,6 +242,9 @@
   'subroutine':
     'prefix': 'sub'
     'body': 'subroutine ${1:name}\n\t$0\nend subroutine $1'
+  'submodule':
+    'prefix': 'subm'
+    'body': 'submodule \(${1:module}\) ${2:name}\n\t$0\nend submodule $2'
   'unpack':
     'prefix': 'unpack'
     'body': 'unpack(${1:vector}, mask=(${2:$1>0}), field=${3:destination array})$0'


### PR DESCRIPTION
Here's a small edit to include a default submodule snippet. I've also noticed that submodules are not correctly highlighted, probably because they are relatively new.

Since I want to learn how to edit grammars, could you explain to me how atom expects to pick up block(s) of code (e.g.  module, subroutine, function, etc.). I'm pretty sure it has to do with the regex of a `procedure`, but I'm no regex expert and am having trouble grokking how this all works.

I'd be happy to keep working on this PR before you merge so that I can learn how atom grammars work.