### PR TITLE
fix indention for 'forall' statement when it is a oneliner

### DIFF
--- a/settings/language-fortran.cson
+++ b/settings/language-fortran.cson
@@ -23,7 +23,7 @@
         |type(?!\\s*(\\(|\\=))
         |(abstract\\s+)?interface\\b
         |([a-z]\\w*\\s*:\\s*)?(
-          (associate|block|critical|do|forall)\\b
+          (associate|block|critical|do|forall.*then)\\b
           |if\\b.*\\bthen\\b
           |select\\s*(case|type)\\b
           |where\\b(?!\\s*\\(.*\\)\\s*[a-z])
@@ -52,7 +52,7 @@
         |type(?!\\s*(\\(|\\=))
         |(abstract\\s+)?interface\\b
         |([a-z]\\w*\\s*:\\s*)?(
-          (associate|block|critical|do|forall)\\b
+          (associate|block|critical|do|forall.*then)\\b
           |if\\b.*\\bthen\\b
           |select\\s*(case|type)\\b
           |where\\b(?!\\s*\\(.*\\)\\s*[a-z])


### PR DESCRIPTION
Fixes the bug where after a forall statement it is alway indenend not considering it could be the one line statement.
FORALL (triplet-spec[, triplet-spec] ...[, mask-expr]) assign-stmt