### PR TITLE
Fixes #120

### DIFF
--- a/grammars/fortran - free form.cson
+++ b/grammars/fortran - free form.cson
@@ -560,7 +560,7 @@
             'patterns':[
               {
                 'comment': 'rest of else line'
-                'begin': '\\G(?!\\s*\\n)'
+                'begin': '\\G(?!\\s*[;!\\n])'
                 'end': '(?=[;!\\n])'
                 'patterns':[
                   {'include': '#invalid-word'}


### PR DESCRIPTION
Adds exception for comment `!` and endline `;` characters to `else` statement lines.