### PR TITLE
Fixes Issue 108 - Autocomment not working for fixed fortran

### DIFF
--- a/settings/language-fortran.cson
+++ b/settings/language-fortran.cson
@@ -1,5 +1,7 @@
 '.source.fortran':
   'editor':
+    'commentStart': '! '
+    'commentEnd': ''
     'increaseIndentPattern': '(?ix)^\\s*(
         (contains|program)\\b
         |do\\b


### PR DESCRIPTION
This adds two lines to settings/language-fortran.cson to make the '!' the default comment character.  This is already the case for all fortran versions specified in settings/language-fortran.cson (free and "modern").  Another solution would be to add entries in that file for fixed and "punchcard" fortran.